### PR TITLE
Updating content

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ access to Compute Engine.
 1. Create the Compute Engine instance
     ```
     # Make sure to use the CentOS 6 image for this demo
-    gcloud compute instances create chef-server --image centos-6 --zone us-central1-b --machine-type n1-standard-1 --scopes compute-rw storage-full
+    gcloud compute instances create chef-server --image centos-6 --zone us-central1-b --machine-type n1-standard-1 --scopes compute-rw,storage-full
     ```
 
 1. SSH to your chef server and then become root
@@ -141,17 +141,17 @@ access to Compute Engine.
     yum update
     ```
 
-1. [Download](http://www.getchef.com/chef/install/) the Chef Server. Select
+1. [Download](https://downloads.chef.io/chef-server) the Chef Server. Select
 *Enterprise Linux, Version 6, x86_64* and the latest version. The page
 should provide a link to the RPM package that you can use to copy/paste
 in your terminal for download. For example,
     ```
-    wget https://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-server-11.1.1-1.el6.x86_64.rpm
+    wget https://web-dl.packagecloud.io/chef/stable/packages/el/6/chef-server-11.1.7-1.el6.x86_64.rpm
     ```
 
 1. Install the package
     ```
-    rpm -i chef-server-11.1.1-1.el6.x86_64.rpm
+    rpm -i chef-server-11.1.7-1.el6.x86_64.rpm
     ```
 
 1. Reconfigure the Chef Server as indicated on the download page
@@ -160,8 +160,8 @@ in your terminal for download. For example,
     ```
 
 1. As instructed on Chef's
-[documentation](http://docs.opscode.com/chef/manage_server_open_source.html#log-in)
-the first thing you should do is to change the default `admin` console
+[documentation](http://docs.chef.io/open_source/)
+the first thing you should do is login and change the default `admin` console
 password. In order to access the web console, you will need to create a
 firewall rule to allow HTTPS (port 443) traffic.  Once that is done, point
 your browser to your Chef Server's public IP (e.g. https://public-ip:443/)
@@ -170,7 +170,7 @@ immediately change the `admin` user's password. You can find your Chef
 Server's public IP in the Developers Console, or with,
    ```
    exit # to quit the 'root' user session
-   gcloud compute firewalls create allow-https --allow=tcp:443
+   gcloud compute firewall-rules create allow-https --allow=tcp:443
    gcloud compute instances get $(hostname -s) | grep natIP | awk '{print $2}'
    ```
 
@@ -183,7 +183,7 @@ will use to develop cookbooks and manage your Chef environment.
 1. Create the Compute Engine instance, this time specify a Debian 7 instance,
     ```
     # Make sure to use the Debian 7 image for this demo
-    gcloud compute instances create chef-workstation --image debian-cloud/global/images/debian-7-v20140606 --zone us-central1-b --machine-type n1-standard-1 --scopes compute-rw storage-full
+    gcloud compute instances create chef-workstation --image debian-7 --zone us-central1-b --machine-type n1-standard-1 --scopes compute-rw,storage-full
     ```
 
 1. SSH to your Chef Workstation
@@ -197,13 +197,14 @@ will use to develop cookbooks and manage your Chef environment.
     sudo apt-get install git build-essential -y
     ```
 
-1. Install Chef with the omnibus installer script,
+1. Install Chef using the latest 11.x package from their page, e.g:
     ```
-    curl -L https://www.opscode.com/chef/install.sh | sudo bash
+    wget https://opscode-omnibus-packages.s3.amazonaws.com/debian/6/x86_64/chef_11.18.12-1_amd64.deb
+    dpkg -i chef_11.18.12-1_amd64.deb
     ```
 
 1. The next few steps are derived from following the Chef Workstation
-[installation instructions](http://docs.opscode.com/install_workstation.html)
+[installation instructions](http://docs.chef.io/open_source/install_workstation.html)
 When finished, you should have a copy of the Chef Server's "validation" PEM
 file, it's `admin.pem` file, and a `knife.rb` file that allows you to
 interact with the Chef Server.
@@ -237,7 +238,7 @@ example of the set up process,
     ```
     WARNING: No knife configuration file found
     Where should I put the config file? ~/chef-repo/.chef/knife.rb
-    Please enter the chef server URL: https://107.178.217.81:443
+    Please enter the chef server URL: https://107.178.0.1:443
     Please enter a name for the new user: erjohnso
     Please enter the existing admin name: admin
     Please enter the location of the existing admin's private key: ~/chef-repo/.chef/admin.pem
@@ -307,7 +308,7 @@ authorization with,
 1. Once setup, you can then use knife-google to create and bootstrap a new
 node with,
     ```
-    knife google server create knife-test -m n1-standard-1 -I debian-7-wheezy-v20150423-Z us-central1-b -i ~/.ssh/google_compute_engine -x $USER
+    knife google server create knife-test -m n1-standard-1 -I debian-7-wheezy-v20150423 -Z us-central1-b -i ~/.ssh/google_compute_engine -x $USER
     ```
 
 1. Once the instance is created and the node registered with the Chef Server,


### PR DESCRIPTION
Updated to fix all the issues I've come across (see summary of changes below), while trying to execute the demo myself.
However, the demo still falls apart on `knife google`:
- Firstly, public gem still has the old API issue, so need to:

```
$ sudo /opt/chef/embedded/bin/gem uninstall google-api-client -v '0.7.1'
$ sudo /opt/chef/embedded/bin/gem uninstall google-api-client
```
- Second, getting errors while trying to get the node set up and from source it doesn't seem to be trivial to figure out:

```
$ knife google server create knife-test -m n1-standard-1 -I debian-7-wheezy-v20150710 -Z us-central1-b -i ~/.ssh/google_compute_engine -x temikus -VV
Looking for Image 'debian-7-wheezy-v20150710' in Project 'myproject'
Looking for Image 'debian-7-wheezy-v20150710' in Project 'debian-cloud'
Found Image 'debian-7-wheezy-v20150710' in Project 'debian-cloud'
Waiting for the disk insert operation to complete
/opt/chef/embedded/lib/ruby/1.9.1/time.rb:265:in `_parse': can't convert nil into String (TypeError)
    from /opt/chef/embedded/lib/ruby/1.9.1/time.rb:265:in `parse'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/knife-google-1.3.1/lib/google/compute/zone_operation.rb:42:in `from_hash'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/knife-google-1.3.1/lib/google/compute/resource.rb:28:in `initialize'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/knife-google-1.3.1/lib/google/compute/creatable_resource_collection.rb:35:in `new'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/knife-google-1.3.1/lib/google/compute/creatable_resource_collection.rb:35:in `create'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/knife-google-1.3.1/lib/google/compute/creatable_resource_collection.rb:45:in `insert'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/knife-google-1.3.1/lib/chef/knife/google_server_create.rb:427:in `run'
    from /opt/chef/embedded/apps/chef/lib/chef/knife.rb:493:in `run_with_pretty_exceptions'
    from /opt/chef/embedded/apps/chef/lib/chef/knife.rb:174:in `run'
    from /opt/chef/embedded/apps/chef/lib/chef/application/knife.rb:139:in `run'
    from /opt/chef/embedded/apps/chef/bin/knife:25:in `<top (required)>'
    from /usr/bin/knife:38:in `load'
    from /usr/bin/knife:38:in `<main>'
```
# 
# Summary of changes:
- Updating deprecated syntax:

```
λ gcloud compute instances create chef-server --image centos-6 --zone
us-central1-b --machine-type n1-standard-1 --scopes compute-rw
storage-full
WARNING: We noticed that you are using space-separated lists, which are
deprecated. Please transition to using comma-separated lists instead
(try "--scopes compute-rw,storage-full"). If you intend to use
[storage-full] as positional arguments, put the flags at the end.
Created
[https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-b/instances/chef-server].
NAME        ZONE          MACHINE_TYPE  PREEMPTIBLE INTERNAL_IP
EXTERNAL_IP   STATUS
chef-server us-central1-b n1-standard-1             10.240.xx.xx
104.154.xx.xx RUNNING
λ gcloud compute instances create chef-server --image centos-6 --zone
us-central1-b --machine-type n1-standard-1 --scopes
compute-rw,storage-full
Created
[https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-b/instances/chef-server].
NAME        ZONE          MACHINE_TYPE  PREEMPTIBLE INTERNAL_IP
EXTERNAL_IP   STATUS
chef-server us-central1-b n1-standard-1             10.240.135.118
104.197.xx.xx RUNNING
```
- Updated to newest Chef 11 package. (This really should be updated to
  Chef12, but it's a lot of work...)
- Chef install link now leads to client, added a proper link to server.
- The documentation links for Chef were leading nowhere, I re-pointed
  them, however, note, that there is no more login section in there. I
  strongly suspect they wanted to remove all traces of default login:pw
  from docs.
- `firewalls` section no longer exists:

```
λ gcloud compute firewalls create allow-https --allow=tcp:443
...
ERROR: (gcloud.compute) Invalid choice: 'firewalls'. Did you mean
'firewall-rules'?

λ gcloud compute firewall-rules create allow-https --allow=tcp:443
(2)
Created
[https://www.googleapis.com/compute/v1/projects/myproject/global/firewalls/allow-https].
NAME        NETWORK SRC_RANGES RULES   SRC_TAGS TARGET_TAGS
allow-https default 0.0.0.0/0  tcp:443
```
- `get` is now `list`:

```
λ gcloud compute instances get chef-server
...

ERROR: (gcloud.compute.instances) Invalid choice: 'get'. Did you mean
'list'?

λ gcloud compute instances list chef-server
NAME        ZONE          MACHINE_TYPE  PREEMPTIBLE INTERNAL_IP
EXTERNAL_IP   STATUS
chef-server us-central1-b n1-standard-1             10.240.135.118
104.197.82.28 RUNNING
```
- The referenced Debian image no longer exists:

```
λ gcloud compute instances create chef-workstation --image
debian-cloud/global/images/debian-7-v20140606 --zone us-central1-b
--machine-type n1-standard-1 --scopes compute-rw,storage-full
ERROR: (gcloud.compute.instances.create) wrong number of fields:
[debian-cloud/global/images/debian-7-v20140606] does not match any of
IMAGE, /PROJECT/IMAGE

λ gcloud compute instances create chef-workstation --image debian-7
--zone us-central1-b --machine-type n1-standard-1 --scopes
compute-rw,storage-full
Created
[https://www.googleapis.com/compute/v1/projects/myproject/zones/us-central1-b/instances/chef-workstation].
NAME             ZONE          MACHINE_TYPE  PREEMPTIBLE INTERNAL_IP
EXTERNAL_IP  STATUS
chef-workstation us-central1-b n1-standard-1             10.240.xx.xx
108.59.xx.xx RUNNING
```
- Chef quick install will install 12x client, which is incompatible with
  the instructions.

/CC @erjohnso 
